### PR TITLE
Add sidebar and enhance notes retrieval

### DIFF
--- a/recepcionista/dashboard.php
+++ b/recepcionista/dashboard.php
@@ -6,13 +6,22 @@ if ($_SESSION['user']['role'] !== 'Recepcionista') exit('Acceso denegado');
 <!DOCTYPE html>
 <html lang="es">
 <head>
-<meta charset="UTF-8"><title>Dashboard Notas</title>
+<meta charset="UTF-8">
+<title>Dashboard Notas</title>
+<style>
+#sidebar{position:fixed;left:-260px;top:0;bottom:0;width:250px;background:#f0f0f0;overflow:auto;transition:left .3s;padding:10px;}
+#sidebar.open{left:0;}
+#toggleSidebar{position:fixed;left:10px;top:10px;z-index:1000;}
+body{margin-left:0;padding-left:0;}
+</style>
 <script>
 document.addEventListener('DOMContentLoaded', function(){
     const dateInput = document.getElementById('selectedDate');
     const noteDate = document.getElementById('noteDate');
+    const sidebar = document.getElementById('sidebar');
+    document.getElementById('toggleSidebar').addEventListener('click',()=>{sidebar.classList.toggle('open');});
     function loadNotes(date){
-        fetch(`get_notes.php?date=${date}`)
+        fetch(`get_notes.php?date=${date}&previous=1&completed=1&order=desc`)
             .then(res=>res.json())
             .then(data=>{
                 ['pendiente','en_proceso','completada'].forEach(status=>{
@@ -20,30 +29,53 @@ document.addEventListener('DOMContentLoaded', function(){
                     ul.innerHTML='';
                     data[status].forEach(note=>{
                         const li=document.createElement('li');
-                        li.innerHTML = `<strong>[${note.status}]</strong> ${note.title} - ${note.username}
-                        <p>${note.content}</p>
-                        <small>${note.created_at}${note.modificado?' ('+note.modificado+')':''}</small>`;
+                        li.innerHTML=`<strong>[${note.status}]</strong> ${note.title} - ${note.username}<p>${note.content}</p><small>${note.created_at}</small>`;
                         ul.appendChild(li);
                     });
                 });
+                const pendientesSidebar=document.getElementById('pendientesSidebar');
+                pendientesSidebar.innerHTML='';
+                if(data.previos){
+                    data.previos.forEach(n=>{
+                        const li=document.createElement('li');
+                        li.textContent=`${n.title} - ${n.username} (${n.status})`;
+                        pendientesSidebar.appendChild(li);
+                    });
+                }
+                const realizadasSidebar=document.getElementById('realizadasSidebar');
+                realizadasSidebar.innerHTML='';
+                if(data.realizadas){
+                    data.realizadas.forEach(n=>{
+                        const li=document.createElement('li');
+                        li.textContent=`${n.created_at.split(' ')[0]} - ${n.title}`;
+                        realizadasSidebar.appendChild(li);
+                    });
+                }
             });
     }
-    dateInput.addEventListener('change', ()=> { noteDate.value = dateInput.value; loadNotes(dateInput.value); });
-    document.getElementById('noteForm').addEventListener('submit', function(e){
+    dateInput.addEventListener('change',()=>{noteDate.value=dateInput.value;loadNotes(dateInput.value);});
+    document.getElementById('noteForm').addEventListener('submit',function(e){
         e.preventDefault();
-        const formData = new FormData(this);
+        const formData=new FormData(this);
         fetch('add_note.php',{method:'POST',body:formData})
             .then(res=>res.json())
-            .then(resp=>{ if(resp.success){ loadNotes(dateInput.value); this.reset(); noteDate.value = dateInput.value; } });
+            .then(resp=>{if(resp.success){loadNotes(dateInput.value);this.reset();noteDate.value=dateInput.value;}});
     });
-    const today = new Date().toISOString().slice(0,10);
-    dateInput.value = today;
-    noteDate.value = today;
+    const today=new Date().toISOString().slice(0,10);
+    dateInput.value=today;
+    noteDate.value=today;
     loadNotes(today);
 });
 </script>
 </head>
 <body>
+<button id="toggleSidebar">☰</button>
+<div id="sidebar">
+    <h3>Tareas Pendientes</h3>
+    <ul id="pendientesSidebar"></ul>
+    <h3>Realizadas</h3>
+    <ul id="realizadasSidebar"></ul>
+</div>
 <h2>Dashboard de Notas</h2>
 <label>Selecciona fecha: <input type="date" id="selectedDate"></label>
 <div id="notesContainer">

--- a/recepcionista/get_notes.php
+++ b/recepcionista/get_notes.php
@@ -2,18 +2,27 @@
 session_start();
 require __DIR__.'/../config/db.php';
 if($_SESSION['user']['role']!=='Recepcionista') exit('Acceso denegado');
+
 $date = $_GET['date'] ?? date('Y-m-d');
-$today = date('Y-m-d');
-$response=[];
+$order = (isset($_GET['order']) && strtolower($_GET['order']) === 'asc') ? 'ASC' : 'DESC';
+
+$response = [];
 foreach(['pendiente','en_proceso','completada'] as $status){
     $stmt = $pdo->prepare('SELECT n.*,u.username FROM notes n JOIN users u ON n.user_id=u.id WHERE DATE(n.created_at)=? AND n.status=? ORDER BY n.created_at');
     $stmt->execute([$date,$status]);
-    $rows = $stmt->fetchAll();
-    $response[$status] = array_map(function($r) use ($date,$today) {
-        $r['modificado'] = ($date!==$today) ? date('Y-m-d H:i:s') : '';
-        return $r;
-    }, $rows);
+    $response[$status] = $stmt->fetchAll();
 }
+
+if(isset($_GET['previous'])){
+    $stmt = $pdo->query('SELECT n.*,u.username FROM notes n JOIN users u ON n.user_id=u.id WHERE DATE(n.created_at) < CURDATE() AND n.status IN (\'pendiente\',\'en_proceso\') ORDER BY n.created_at DESC');
+    $response['previos'] = $stmt->fetchAll();
+}
+
+if(isset($_GET['completed'])){
+    $stmt = $pdo->query("SELECT n.*,u.username FROM notes n JOIN users u ON n.user_id=u.id WHERE n.status='completada' ORDER BY n.created_at $order");
+    $response['realizadas'] = $stmt->fetchAll();
+}
+
 header('Content-Type: application/json');
 echo json_encode($response);
 ?>


### PR DESCRIPTION
## Summary
- implement collapsible sidebar on the receptionist dashboard
- show historical tasks in sidebar
- extend notes endpoint to fetch previous pending tasks and completed tasks with sorting

## Testing
- `php -l recepcionista/get_notes.php`
- `php -l recepcionista/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68786c07928483258006d97ba2062ddf